### PR TITLE
fix: can't change the DemoElement's own style

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,14 +38,14 @@ for multiple levels of data binding. This is because internally the `setState` m
 - `hide()`, hide the element
 - `select(selector: string)`, select an element from the component's Shadow DOM (calls `querySelector` internally)
 - `selectAll(selector: string)`, select multiple elements from the component's Shadow DOM (calls `querySelectorAll` internally)
-- `style(element: HTMLElement, styles: Object)`, set multiple styles on an element at once
+- `css(element: HTMLElement, styles: Object)`, set multiple styles on an element at once
 
 Example: 
 
 ```
 const container = this.shadowRoot.querySelector('#container');
 
-this.style(container, {
+this.css(container, {
   display: 'flex'  
   paddingBottom: '10px',
   backgroundColor: '#ff0000'

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -73,7 +73,7 @@ export class CustomElement extends HTMLElement {
     this.setAttribute('hidden', '');
   }
 
-  style(element, styles) {
+  css(element, styles) {
     Object.assign(element.style, styles);
   }
 

--- a/test/custom-element.test.js
+++ b/test/custom-element.test.js
@@ -183,7 +183,7 @@ describe('custom-element', () => {
       textAlign: 'center'
     };
 
-    element.style(heading, styles);
+    element.css(heading, styles);
 
     Object.entries(styles).forEach(([prop, style]) => {
       assert.equal(heading.style[prop], style);


### PR DESCRIPTION
```js
const heading = element.select('h3');
const styles = {
  color: 'red',
};

element.style(heading, styles);
```

Although this can change the style of other elements, it can't change its own style, because `element.style` is overridden by the `style` method. When you using `el.style(el, { /*
some styles */ })`, the `element.style` in this method is this method, not the style object of the element.

```js
const styles = {
  color: 'red',
};

element.style(element, styles); // nothing changes, now the style method has a color prop
```

To avoid this, just change the name of this method.